### PR TITLE
Disable "use strict" since it breaks iOS webpacks.

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -8,6 +8,7 @@
         "sourceMap": false,
         "declaration": false,
         "noLib": false,
+        "noImplicitUseStrict": true,
         "experimentalDecorators": true,
         "lib": [
             "es2016"


### PR DESCRIPTION
Addresses https://github.com/NativeScript/nativescript-camera/issues/8
