### PR TITLE
Disable "use strict" since it breaks iOS webpacks.

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -8,6 +8,7 @@
         "sourceMap": false,
         "declaration": false,
         "noLib": false,
+        "noImplicitUseStrict": true,
         "experimentalDecorators": true,
         "lib": [
             "es2016"

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -8,7 +8,7 @@
         "sourceMap": false,
         "declaration": false,
         "noLib": false,
-        "noImplicitUseStrict": true,
+        "noEmitHelpers": true,
         "experimentalDecorators": true,
         "lib": [
             "es2016"


### PR DESCRIPTION
Addresses issue #8
