### PR TITLE
Selfie mode: added a 'cameraFacing' (front|rear) option

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -87,7 +87,7 @@ __Example 2__ shows how to take a picture using the NativeScript camera module. 
 * __height__: The desired height of the picture (in device independent pixels).
 * __keepAspectRatio__: A boolean parameter that indicates if the aspect ratio should be kept.
 * __saveToGallery__: A boolean parameter that indicates if the taken photo will be saved in "Photos" for Android and in "Camera Roll" in iOS
-* __cameraFacing__: Start with either the "front" or "rear" (default) camera of the device.
+* __cameraFacing__: Start with either the "front" or "rear" (default) camera of the device. The current implementation doesn't work on all Android devices, in which case it falls back to the default behavior.
 
 What does `device independent pixels` mean? The NativeScript layout mechanism uses device-independent pixels when measuring UI controls. This allows you to declare one layout and this layout will look similar to all devices (no matter the device's display resolution). In order to get a proper image quality for high resolution devices (like iPhone retina and Android Full HD), camera will return an image with bigger dimensions. For example, if we request an image that is 100x100, on iPhone 6 the actual image will be 200x200 (since its display density factor is 2 -> 100*2x100*2).
 Setting the `keepAspectRatio` property could result in a different than requested width or height. The camera will return an image with the correct aspect ratio but generally only one (from width and height) will be the same as requested; the other value will be calculated in order to preserve the aspect of the original image.

--- a/src/README.md
+++ b/src/README.md
@@ -87,6 +87,7 @@ __Example 2__ shows how to take a picture using the NativeScript camera module. 
 * __height__: The desired height of the picture (in device independent pixels).
 * __keepAspectRatio__: A boolean parameter that indicates if the aspect ratio should be kept.
 * __saveToGallery__: A boolean parameter that indicates if the taken photo will be saved in "Photos" for Android and in "Camera Roll" in iOS
+* __cameraFacing__: Start with either the "front" or "rear" (default) camera of the device.
 
 What does `device independent pixels` mean? The NativeScript layout mechanism uses device-independent pixels when measuring UI controls. This allows you to declare one layout and this layout will look similar to all devices (no matter the device's display resolution). In order to get a proper image quality for high resolution devices (like iPhone retina and Android Full HD), camera will return an image with bigger dimensions. For example, if we request an image that is 100x100, on iPhone 6 the actual image will be 200x200 (since its display density factor is 2 -> 100*2x100*2).
 Setting the `keepAspectRatio` property could result in a different than requested width or height. The camera will return an image with the correct aspect ratio but generally only one (from width and height) will be the same as requested; the other value will be calculated in order to preserve the aspect of the original image.

--- a/src/nativescript-camera.android.ts
+++ b/src/nativescript-camera.android.ts
@@ -63,6 +63,10 @@ export var takePicture = function (options?): Promise<any> {
 
             takePictureIntent.putExtra(android.provider.MediaStore.EXTRA_OUTPUT, tempPictureUri);
 
+            if (options && options.cameraFacing === "front") {
+                takePictureIntent.putExtra("android.intent.extras.CAMERA_FACING", android.hardware.Camera.CameraInfo.CAMERA_FACING_FRONT);
+            }
+
             if (takePictureIntent.resolveActivity(utils.ad.getApplicationContext().getPackageManager()) != null) {
 
                 let appModule: typeof applicationModule = require("application");

--- a/src/nativescript-camera.d.ts
+++ b/src/nativescript-camera.d.ts
@@ -41,4 +41,9 @@ export interface CameraOptions {
      * Defines if camera picture should be copied to photo Gallery (Android) or Photos (iOS) 
      */
     saveToGallery?: boolean;
+
+    /**
+     * The initial camera. Default "rear".
+     */
+    cameraFacing?: "front" | "rear";
 }

--- a/src/nativescript-camera.d.ts
+++ b/src/nativescript-camera.d.ts
@@ -44,6 +44,7 @@ export interface CameraOptions {
 
     /**
      * The initial camera. Default "rear".
+     * The current implementation doesn't work on all Android devices, in which case it falls back to the default behavior.
      */
     cameraFacing?: "front" | "rear";
 }

--- a/src/nativescript-camera.ios.ts
+++ b/src/nativescript-camera.ios.ts
@@ -155,6 +155,7 @@ export var takePicture = function (options): Promise<any> {
         if (mediaTypes) {
             imagePickerController.mediaTypes = mediaTypes;
             imagePickerController.sourceType = sourceType;
+            imagePickerController.cameraDevice = options && options.cameraFacing === "front" ? UIImagePickerControllerCameraDevice.Front : UIImagePickerControllerCameraDevice.Rear;
         }
 
         imagePickerController.modalPresentationStyle = UIModalPresentationStyle.CurrentContext;


### PR DESCRIPTION
Added an option to start with the "front" camera.

Note that on Android this uses a (very popular) unofficial API which may or may not work with a particular device. Google recommends a different approach for newer devices but until that's researched and added, this PR will at least enable this feature for all iOS and most Android devices.