### PR TITLE
Handle user pressing cancel button, on Android

### DIFF
--- a/src/camera.android.ts
+++ b/src/camera.android.ts
@@ -82,6 +82,9 @@ export let takePicture = function (options?): Promise<any> {
 
                 let appModule: typeof applicationModule = require("tns-core-modules/application");
 
+                // Remove previous listeners if any
+                appModule.android.off("activityResult");
+                
                 appModule.android.on("activityResult", (args) => {
                     const requestCode = args.requestCode;
                     const resultCode = args.resultCode;

--- a/src/camera.android.ts
+++ b/src/camera.android.ts
@@ -125,6 +125,9 @@ export let takePicture = function (options?): Promise<any> {
                             keepAspectRatio: shouldKeepAspectRatio
                         };
                         resolve(asset);
+                    } else if (resultCode === android.app.Activity.RESULT_CANCELED) {
+                        // User cancelled the image capture
+                        reject("cancelled");
                     }
                 });
 


### PR DESCRIPTION
If this PR is merged,
When user cancels image capture, the promise is rejected with a message "cancelled"
{onAndroid}