### PR TITLE
fix: saveToGallery to default to true on both platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npm install nativescript-camera --save
 | width | 0 | Defines the desired width (in device independent pixels) of the taken image. It should be used with height property. If `keepAspectRatio` actual image width could be different in order to keep the aspect ratio of the original camera image. The actual image width will be greater than requested if the display density of the device is higher (than 1) (full HD+ resolutions). |
 | height | 0 | Defines the desired height (in device independent pixels) of the taken image. It should be used with width property. If `keepAspectRatio` actual image width could be different in order to keep the aspect ratio of the original camera image. The actual image height will be greater than requested if the display density of the device is higher (than 1) (full HD+ resolutions). |
 | keepAspectRatio | true | Defines if camera picture aspect ratio should be kept during picture resizing. This property could affect width or height return values. |
-| saveToGallery | false | Defines if camera picture should be copied to photo Gallery (Android) or Photos (iOS) |
+| saveToGallery | true | Defines if camera picture should be copied to photo Gallery (Android) or Photos (iOS) |
 | cameraFacing | rear | The initial camera facing. Use 'front' for selfies. |
 
 ## Usage 

--- a/demo/package.json
+++ b/demo/package.json
@@ -46,6 +46,7 @@
     "typescript": "~2.2.2",
     "webpack": "~3.8.1",
     "webpack-bundle-analyzer": "^2.8.2",
-    "webpack-sources": "~1.0.1"
+    "webpack-sources": "~1.0.1",
+    "uglifyjs-webpack-plugin": "~1.1.6"
   }
 }

--- a/src/camera.android.ts
+++ b/src/camera.android.ts
@@ -25,17 +25,17 @@ export let takePicture = function (options?): Promise<any> {
             let types: typeof typesModule = require("tns-core-modules/utils/types");
             let utils: typeof utilsModule = require("tns-core-modules/utils/utils");
 
-            let saveToGallery;
-            let reqWidth;
-            let reqHeight;
-            let shouldKeepAspectRatio;
+            let saveToGallery = true;
+            let reqWidth = 0;
+            let reqHeight = 0;
+            let shouldKeepAspectRatio = true;
 
             let density = utils.layout.getDisplayDensity();
             if (options) {
-                saveToGallery = options.saveToGallery ? true : false;
-                reqWidth = options.width ? options.width * density : 0;
+                saveToGallery = types.isNullOrUndefined(options.saveToGallery) ? saveToGallery : options.saveToGallery;
+                reqWidth = options.width ? options.width * density : reqWidth;
                 reqHeight = options.height ? options.height * density : reqWidth;
-                shouldKeepAspectRatio = types.isNullOrUndefined(options.keepAspectRatio) ? true : options.keepAspectRatio;
+                shouldKeepAspectRatio = types.isNullOrUndefined(options.keepAspectRatio) ? shouldKeepAspectRatio : options.keepAspectRatio;
             }
 
             if ((<any>android.support.v4.content.ContextCompat).checkSelfPermission(
@@ -77,6 +77,9 @@ export let takePicture = function (options?): Promise<any> {
             if (options && options.cameraFacing === "front") {
                 takePictureIntent.putExtra("android.intent.extras.CAMERA_FACING",
                     android.hardware.Camera.CameraInfo.CAMERA_FACING_FRONT);
+            } else {
+                takePictureIntent.putExtra("android.intent.extras.CAMERA_FACING",
+                    android.hardware.Camera.CameraInfo.CAMERA_FACING_BACK);
             }
 
             if (takePictureIntent.resolveActivity(utils.ad.getApplicationContext().getPackageManager()) != null) {

--- a/src/camera.ios.ts
+++ b/src/camera.ios.ts
@@ -124,8 +124,8 @@ export let takePicture = function (options): Promise<any> {
         if (options) {
             reqWidth = options.width || 0;
             reqHeight = options.height || reqWidth;
-            keepAspectRatio = types.isNullOrUndefined(options.keepAspectRatio) ? true : options.keepAspectRatio;
-            saveToGallery = options.saveToGallery ? true : false;
+            keepAspectRatio = types.isNullOrUndefined(options.keepAspectRatio) ? keepAspectRatio : options.keepAspectRatio;
+            saveToGallery = types.isNullOrUndefined(options.saveToGallery) ? saveToGallery : options.saveToGallery;
         }
 
         let authStatus = PHPhotoLibrary.authorizationStatus();

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nativescript-camera",
-    "version": "3.2.1",
+    "version": "4.0.0",
     "description": "Provides API for using device camera",
     "repository": {
         "type": "git",


### PR DESCRIPTION

BREAKING CHANGES:
Until now, saveToGallery property on Android had default value 'false'. To unify it with iOS we enable it by default.

Migration steps:
To preserve the previous behavior on Android you should explicitly set the value in your app.

```
...
camera.takePicture({saveToGallery:false}) 
```
