### PR TITLE
Allow seperate requests for Camera & Photos perms

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ npm install nativescript-camera --save
 | Method | Description |
 | --- | --- |
 | takePicture(options?: CameraOptions) | Take a photo using the camera with an optional parameter for setting different camera options. |
-| requestPermissions() | Check required permissions for using device camera. Returns a Promise. |
+| requestPermissions() | Request permission from the user for access to their saved photos as well as access to their camera. Returns a Promise. |
+| requestCameraPermissions() | Request permission from the user for access to their camera. Returns a Promise. |
+| requestPhotosPermissions() | Request permission from the user for access to their saved photos. Returns a Promise. |
 | isAvailable() | Is the device camera available to use. |
 
 ### CameraOptions

--- a/src/camera.android.ts
+++ b/src/camera.android.ts
@@ -174,6 +174,18 @@ export let requestPermissions = function () {
     ]);
 };
 
+export let requestPhotosPermissions = function () {
+    return permissions.requestPermissions([
+        (<any>android).Manifest.permission.WRITE_EXTERNAL_STORAGE,
+    ]);
+};
+
+export let requestCameraPermissions = function () {
+    return permissions.requestPermissions([
+        (<any>android).Manifest.permission.CAMERA
+    ]);
+};
+
 let createDateTimeStamp = function () {
     let result = "";
     let date = new Date();

--- a/src/camera.ios.ts
+++ b/src/camera.ios.ts
@@ -200,7 +200,7 @@ export let requestPermissions = function () {
     });
 };
 
-let requestPhotosPermissions = function () {
+export let requestPhotosPermissions = function () {
     return new Promise(function (resolve, reject) {
         let authStatus = PHPhotoLibrary.authorizationStatus();
         switch (authStatus) {
@@ -236,7 +236,7 @@ let requestPhotosPermissions = function () {
     });
 };
 
-let requestCameraPermissions = function () {
+export let requestCameraPermissions = function () {
     return new Promise(function (resolve, reject) {
         let cameraStatus = AVCaptureDevice.authorizationStatusForMediaType(AVMediaTypeVideo);
         switch (cameraStatus) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,6 +10,8 @@ export function takePicture(options?: CameraOptions): Promise<imageAsset.ImageAs
  * Check required permissions for using device camera.
  */
 export function requestPermissions(): Promise<any>;
+export function requestCameraPermissions(): Promise<any>;
+export function requestPhotosPermissions(): Promise<any>;
 
 /**
  * Is the camera available to use


### PR DESCRIPTION
In some use cases, permission for the camera is all that's needed. This change allows people to request either permission individually.