### PR TITLE
feat: allowsEditing on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,14 @@ npm install nativescript-camera --save
 | isAvailable() | Is the device camera available to use. |
 
 ### CameraOptions
-| Property | Default | Description |
-| --- | --- | --- |
-| width | 0 | Defines the desired width (in device independent pixels) of the taken image. It should be used with height property. If `keepAspectRatio` actual image width could be different in order to keep the aspect ratio of the original camera image. The actual image width will be greater than requested if the display density of the device is higher (than 1) (full HD+ resolutions). |
-| height | 0 | Defines the desired height (in device independent pixels) of the taken image. It should be used with width property. If `keepAspectRatio` actual image width could be different in order to keep the aspect ratio of the original camera image. The actual image height will be greater than requested if the display density of the device is higher (than 1) (full HD+ resolutions). |
-| keepAspectRatio | true | Defines if camera picture aspect ratio should be kept during picture resizing. This property could affect width or height return values. |
-| saveToGallery | true | Defines if camera picture should be copied to photo Gallery (Android) or Photos (iOS) |
-| cameraFacing | rear | The initial camera facing. Use 'front' for selfies. |
+| Property | Default | Platform | Description |
+| --- | --- | --- | --- |
+| width | 0 | Both | Defines the desired width (in device independent pixels) of the taken image. It should be used with height property. If `keepAspectRatio` actual image width could be different in order to keep the aspect ratio of the original camera image. The actual image width will be greater than requested if the display density of the device is higher (than 1) (full HD+ resolutions). |
+| height | 0 | Both | Defines the desired height (in device independent pixels) of the taken image. It should be used with width property. If `keepAspectRatio` actual image width could be different in order to keep the aspect ratio of the original camera image. The actual image height will be greater than requested if the display density of the device is higher (than 1) (full HD+ resolutions). |
+| keepAspectRatio | true | Both | Defines if camera picture aspect ratio should be kept during picture resizing. This property could affect width or height return values. |
+| saveToGallery | true | Both | Defines if camera picture should be copied to photo Gallery (Android) or Photos (iOS) |
+| allowsEditing | false | iOS | Defines if camera "Retake" or "Use Photo" screen forces the user to crop camera picture to a square and optionally lets them zoom in. |
+| cameraFacing | rear | Both | The initial camera facing. Use 'front' for selfies. |
 
 
 > Note: The `saveToGallery` option might have unexpected behavior on Android! Some vendor camera apps (e.g. LG) will save all captured images to the gallery regardless of what the value of `saveToGallery` is. This behavior cannot be controlled by the camera plugin and if you must exclude the captured image from the photo gallery, you will need to get a local storage read/write permission and write custom code to find the gallery location and delete the new image from there.
@@ -131,6 +132,7 @@ __Example 2__ shows how to take a picture using the NativeScript camera module. 
 * __height__: The desired height of the picture (in device independent pixels).
 * __keepAspectRatio__: A boolean parameter that indicates if the aspect ratio should be kept.
 * __saveToGallery__: A boolean parameter that indicates if the original taken photo will be saved in "Photos" for Android and in "Camera Roll" in iOS
+* __allowsEditing__: (iOS Only) A boolean parameter that indicates if the camera "Retake" or "Use Photo" screen forces the user to crop camera picture to a square and optionally lets them zoom in.
 * __cameraFacing__: Start with either the "front" or "rear" (default) camera of the device. The current implementation doesn't work on all Android devices, in which case it falls back to the default behavior.
 
 What does `device independent pixels` mean? The NativeScript layout mechanism uses device-independent pixels when measuring UI controls. This allows you to declare one layout and this layout will look similar to all devices (no matter the device's display resolution). In order to get a proper image quality for high resolution devices (like iPhone retina and Android Full HD), camera will return an image with bigger dimensions. For example, if we request an image that is 100x100, on iPhone 6 the actual image will be 200x200 (since its display density factor is 2 -> 100*2x100*2).

--- a/demo-angular/app/app.component.html
+++ b/demo-angular/app/app.component.html
@@ -5,6 +5,10 @@
                 <Label text="saveToGallery"></Label>
                 <Switch [(ngModel)]="saveToGallery"></Switch>
             </StackLayout>
+            <StackLayout android:visibility="collapsed" orientation="horizontal" padding="10">
+                <Label text="allowsEditing"></Label>
+                <Switch [(ngModel)]="allowsEditing"></Switch>
+            </StackLayout>
             <StackLayout orientation="horizontal" padding="10">
                 <Label text="keepAspectRatio"></Label>
                 <Switch [(ngModel)]="keepAspectRatio"></Switch>

--- a/demo-angular/app/app.component.ts
+++ b/demo-angular/app/app.component.ts
@@ -8,6 +8,7 @@ import { ImageAsset } from 'tns-core-modules/image-asset';
 })
 export class AppComponent {
     public saveToGallery: boolean = false;
+    public allowsEditing: boolean = false;
     public keepAspectRatio: boolean = true;
     public width: number = 320;
     public height: number = 240;
@@ -20,7 +21,7 @@ export class AppComponent {
     onTakePictureTap(args) {
         requestPermissions().then(
             () => {
-                takePicture({ width: this.width, height: this.height, keepAspectRatio: this.keepAspectRatio, saveToGallery: this.saveToGallery })
+                takePicture({ width: this.width, height: this.height, keepAspectRatio: this.keepAspectRatio, saveToGallery: this.saveToGallery, allowsEditing: this.allowsEditing })
                     .then((imageAsset: any) => {
                         this.cameraImage = imageAsset;
                         let that = this;

--- a/demo-vue/app/components/Home.vue
+++ b/demo-vue/app/components/Home.vue
@@ -10,6 +10,10 @@
                     <Label text="saveToGallery" />
                     <Switch v-model="saveToGallery"/>
                 </StackLayout>
+                <StackLayout android:visibility="collapsed" orientation="horizontal" row="0" padding="5">
+                    <Label text="allowsEditing" />
+                    <Switch v-model="allowsEditing"/>
+                </StackLayout>
                 <StackLayout orientation="horizontal" row="0" padding="5">
                     <Label text="keepAspectRatio" />
                     <Switch v-model="keepAspectRatio"/>
@@ -37,6 +41,7 @@
         data() {
             return {
                 saveToGallery: false,
+                allowsEditing: false,
                 keepAspectRatio: true,
                 width: 320,
                 height: 240,
@@ -50,7 +55,7 @@
                 let that = this;
                 requestPermissions().then(
                     () => {
-                        takePicture({ width: that.width, height: that.height, keepAspectRatio: that.keepAspectRatio, saveToGallery: that.saveToGallery }).
+                        takePicture({ width: that.width, height: that.height, keepAspectRatio: that.keepAspectRatio, saveToGallery: that.saveToGallery, allowsEditing: that.allowsEditing }).
                             then((imageAsset) => {
                                 that.cameraImage = imageAsset;
                                 imageAsset.getImageAsync(function (nativeImage) {

--- a/demo/app/main-page.ts
+++ b/demo/app/main-page.ts
@@ -14,6 +14,7 @@ export function navigatingTo(args: EventData) {
     page.bindingContext = fromObject({
         cameraImage: picturePath,
         saveToGallery: false,
+        allowsEditing:  false,
         keepAspectRatio: true,
         width: 320,
         height: 240
@@ -23,12 +24,13 @@ export function navigatingTo(args: EventData) {
 export function onTakePictureTap(args: EventData) {
     let page = <Page>(<View>args.object).page;
     let saveToGallery = page.bindingContext.get("saveToGallery");
+    let allowsEditing = page.bindingContext.get("allowsEditing");
     let keepAspectRatio = page.bindingContext.get("keepAspectRatio");
     let width = page.bindingContext.get("width");
     let height = page.bindingContext.get("height");
     requestPermissions().then(
         () => {
-            takePicture({ width: width, height: height, keepAspectRatio: keepAspectRatio, saveToGallery: saveToGallery }).
+            takePicture({ width: width, height: height, keepAspectRatio: keepAspectRatio, saveToGallery: saveToGallery, allowsEditing: allowsEditing }).
                 then((imageAsset) => {
                     page.bindingContext.set("cameraImage", imageAsset);
                     imageAsset.getImageAsync(function (nativeImage) {

--- a/demo/app/main-page.xml
+++ b/demo/app/main-page.xml
@@ -6,6 +6,10 @@
                     <Label text="saveToGallery" />
                     <Switch checked="{{ saveToGallery }}"/>
                 </StackLayout>
+                <StackLayout android:visibility="collapsed" orientation="horizontal" row="0" padding="5">
+                    <Label text="allowsEditing" />
+                    <Switch checked="{{ allowsEditing }}"/>
+                </StackLayout>
                 <StackLayout orientation="horizontal" row="0" padding="5">
                     <Label text="keepAspectRatio" />
                     <Switch checked="{{ keepAspectRatio }}"/>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -45,6 +45,12 @@ export interface CameraOptions {
     saveToGallery?: boolean;
 
     /**
+     * iOS Only
+     * Defines if camera "Retake" or "Use Photo" screen forces user to crop camera picture to a square and optionally lets them zoom in.
+     */
+    allowsEditing?: boolean;
+
+    /**
      * The initial camera. Default "rear".
      * The current implementation doesn't work on all Android devices, in which case it falls back to the default behavior.
      */


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [x] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
[https://github.com/NativeScript/nativescript-camera/issues/180](url)
## What is the new behavior?
<!-- Describe the changes. -->
Setting the allowsEditing option to true adds a square crop to images on iOS on the "Retake" "Use Photo" screen. This also allows users to "zoom/crop" after the picture has been taken but before it is used.
Implements #[180].


