### PR TITLE
feat: androidx support

### DIFF
--- a/src/camera.android.ts
+++ b/src/camera.android.ts
@@ -7,14 +7,17 @@ import * as platform from "tns-core-modules/platform/platform";
 import * as permissions from "nativescript-permissions";
 
 let REQUEST_IMAGE_CAPTURE = 3453;
+declare let global: any;
+
+let useAndroidX = function () {
+    return global.androidx && global.androidx.appcompat;
+};
+const FileProviderPackageName = useAndroidX() ? global.androidx.core.content : android.support.v4.content;
 
 export let takePicture = function (options?): Promise<any> {
     return new Promise((resolve, reject) => {
         try {
-            if ((<any>android.support.v4.content.ContextCompat).checkSelfPermission(
-                applicationModule.android.context,
-                (<any>android).Manifest.permission.CAMERA) !== android.content.pm.PackageManager.PERMISSION_GRANTED) {
-
+            if (!permissions.hasPermission(android.Manifest.permission.CAMERA)) {
                 reject(new Error("Application does not have permissions to use Camera"));
 
                 return;
@@ -36,9 +39,7 @@ export let takePicture = function (options?): Promise<any> {
                 shouldKeepAspectRatio = types.isNullOrUndefined(options.keepAspectRatio) ? shouldKeepAspectRatio : options.keepAspectRatio;
             }
 
-            if ((<any>android.support.v4.content.ContextCompat).checkSelfPermission(
-                applicationModule.android.context,
-                (<any>android).Manifest.permission.WRITE_EXTERNAL_STORAGE) !== android.content.pm.PackageManager.PERMISSION_GRANTED) {
+            if (!permissions.hasPermission(android.Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
 
                 saveToGallery = false;
             }
@@ -62,7 +63,7 @@ export let takePicture = function (options?): Promise<any> {
 
             let sdkVersionInt = parseInt(platform.device.sdkVersion);
             if (sdkVersionInt >= 21) {
-                tempPictureUri = (<any>android.support.v4.content).FileProvider.getUriForFile(
+                tempPictureUri = FileProviderPackageName.FileProvider.getUriForFile(
                     applicationModule.android.context,
                     applicationModule.android.nativeApp.getPackageName() + ".provider", nativeFile);
             } else {
@@ -169,20 +170,20 @@ export let isAvailable = function () {
 
 export let requestPermissions = function () {
     return permissions.requestPermissions([
-      (<any>android).Manifest.permission.WRITE_EXTERNAL_STORAGE,
-      (<any>android).Manifest.permission.CAMERA
+      android.Manifest.permission.WRITE_EXTERNAL_STORAGE,
+      android.Manifest.permission.CAMERA
     ]);
 };
 
 export let requestPhotosPermissions = function () {
     return permissions.requestPermissions([
-        (<any>android).Manifest.permission.WRITE_EXTERNAL_STORAGE,
+        android.Manifest.permission.WRITE_EXTERNAL_STORAGE,
     ]);
 };
 
 export let requestCameraPermissions = function () {
     return permissions.requestPermissions([
-        (<any>android).Manifest.permission.CAMERA
+        android.Manifest.permission.CAMERA
     ]);
 };
 

--- a/src/package.json
+++ b/src/package.json
@@ -43,7 +43,7 @@
     ],
     "author": "NativeScript team",
     "dependencies": {
-        "nativescript-permissions": "^1.2.3"
+        "nativescript-permissions": "~1.3.0"
     },
     "devDependencies": {
         "tns-core-modules": "^5.0.0",


### PR DESCRIPTION
## What is the current behavior?
The plugin is not compatible with  _androidx_ versions of _tns-core-modules_ and _tns-android_.

## What is the new behavior?
The plugin is compatible with  both _official_ and _androidx_ versions of _tns-core-modules_ and _tns-android_.

Related with https://github.com/NativeScript/nativescript-camera/issues/197.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->
