### PR TITLE
bugfix(android): Fixes crash on sdk27+ devices when saving to gallery

### DIFF
--- a/src/camera.android.ts
+++ b/src/camera.android.ts
@@ -52,9 +52,13 @@ export let takePicture = function (options?): Promise<any> {
             let tempPictureUri;
 
             if (saveToGallery) {
-                picturePath = android.os.Environment.getExternalStoragePublicDirectory(
-                    android.os.Environment.DIRECTORY_DCIM).getAbsolutePath() + "/Camera/" + "NSIMG_" + dateStamp + ".jpg";
-
+                // reference the expected public output dir
+                const dir = android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_DCIM).getAbsolutePath() + "/Camera/";
+                const dirFile = new java.io.File(dir);
+                // and create it, if it doesn't exist (Android won't do it on 28+)
+                if (!dirFile.exists())
+                    dirFile.mkdir();
+                picturePath = dirFile.getAbsolutePath() + "/NSIMG_" + dateStamp + ".jpg";
                 nativeFile = new java.io.File(picturePath);
             } else {
                 picturePath = utils.ad.getApplicationContext().getExternalFilesDir(null).getAbsolutePath() + "/" + "NSIMG_" + dateStamp + ".jpg";
@@ -109,6 +113,12 @@ export let takePicture = function (options?): Promise<any> {
                                         trace.categories.Debug);
                                 }
                             }
+                        }
+
+                        // verify that there is a file where we expect one
+                        const picFile = new java.io.File(picturePath);
+                        if (! picFile.exists()) {
+                            return reject('Cannot locate the picture file');
                         }
 
                         let exif = new android.media.ExifInterface(picturePath);

--- a/src/camera.android.ts
+++ b/src/camera.android.ts
@@ -53,12 +53,12 @@ export let takePicture = function (options?): Promise<any> {
 
             if (saveToGallery) {
                 // reference the expected public output dir
-                const dir = android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_DCIM).getAbsolutePath() + "/Camera/";
-                const dirFile = new java.io.File(dir);
+                const outputPath = android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_DCIM).getAbsolutePath() + "/Camera/";
+                const outputDir = new java.io.File(outputPath);
                 // and create it, if it doesn't exist (Android won't do it on 28+)
-                if (!dirFile.exists())
-                    dirFile.mkdir();
-                picturePath = dirFile.getAbsolutePath() + "/NSIMG_" + dateStamp + ".jpg";
+                if (!outputDir.exists())
+                    outputDir.mkdir();
+                picturePath = outputDir.getAbsolutePath() + "/NSIMG_" + dateStamp + ".jpg";
                 nativeFile = new java.io.File(picturePath);
             } else {
                 picturePath = utils.ad.getApplicationContext().getExternalFilesDir(null).getAbsolutePath() + "/" + "NSIMG_" + dateStamp + ".jpg";


### PR DESCRIPTION
## PR Checklist

- [x ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ x] All existing tests are passing
- [ x] Tests for the changes are included

## What is the current behavior?
On android devices running 27+ the app crashes when saving to the gallery. 
This is caused by the creation of the `picturePath`. On 27+ devices the "Camera" directory is not created in the DCIM dir. 

## What is the new behavior?
The new code creates the 'Camera' directory if it does not exist. 
Then verifies that there is a file at the expected location

Fixes/Implements/Closes #[225, 236].
BREAKING CHANGES: none
Migration steps: none


